### PR TITLE
added helper scripts dir with shell scripts and notebook

### DIFF
--- a/helper_scripts/cleaner.ipynb
+++ b/helper_scripts/cleaner.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2990b3fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import os\n",
+    "import json\n",
+    "from lxml import etree\n",
+    "import cv2\n",
+    "from collections import OrderedDict\n",
+    "from tqdm import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bbd4ddb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session = '18_01_2023_session_7'\n",
+    "video = 'DJI_0068'\n",
+    "video_location = f\"/fs/ess/PAS2136/Kenya-2023/Zebras/session_data/{session}/drone/\"\n",
+    "annotation_location = \"/cvat_export/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8fb0b90f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# video_path = f\"{path}/video.mp4\"\n",
+    "video_path = f\"{video_location}/videos/{video}.MP4\"\n",
+    "# annotation_path = f\"{path}/tracks.xml\"\n",
+    "#annotation_path = f\"{annotation_location}{session}-{video}-annotations.xml\"\n",
+    "annotation_path = \"/fs/ess/PAS2136/Kenya-2023/Zebras/methods_paper_analysis/annotation_process/cvat_export/18_01_2023_session_7-DJI_0068-annotations.xml\"\n",
+    "\n",
+    "root = etree.parse(annotation_path).getroot()\n",
+    "annotated = dict()\n",
+    "track2end = {}\n",
+    "\n",
+    "for track in root.iterfind(\"track\"):\n",
+    "    track_id = int(track.attrib[\"id\"])\n",
+    "\n",
+    "    for box in track.iter(\"box\"):\n",
+    "        frame_id = int(box.attrib[\"frame\"])\n",
+    "        keyframe = int(box.attrib[\"keyframe\"])\n",
+    "\n",
+    "        if keyframe == 1:\n",
+    "            track2end[track_id] = frame_id\n",
+    "\n",
+    "for track in root.iterfind(\"track\"):\n",
+    "    track_id = int(track.attrib[\"id\"])\n",
+    "\n",
+    "    for box in track.iter(\"box\"):\n",
+    "        frame_id = int(box.attrib[\"frame\"])\n",
+    "        keyframe = int(box.attrib[\"keyframe\"])\n",
+    "\n",
+    "        if frame_id <= track2end[track_id]:\n",
+    "            if annotated.get(track_id) is None:\n",
+    "                annotated[track_id] = OrderedDict()\n",
+    "                \n",
+    "            scaling_factor = 3\n",
+    "\n",
+    "            annotated[track_id][frame_id] = [int(float(box.attrib[\"xtl\"])*scaling_factor),\n",
+    "                                                int(float(box.attrib[\"ytl\"])*scaling_factor),\n",
+    "                                                int(float(box.attrib[\"xbr\"])*scaling_factor),\n",
+    "                                                int(float(box.attrib[\"ybr\"])*scaling_factor), keyframe]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a63042c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tracks_location = \"/fs/ess/PAS2136/Kenya-2023/Zebras/methods_paper_analysis/annotation_process/tracks/\"\n",
+    "\n",
+    "xml_page = etree.Element(\"annotations\")\n",
+    "etree.SubElement(xml_page, \"version\").text = \"1.1\"\n",
+    "\n",
+    "for track_id in annotated.keys():\n",
+    "    xml_track = etree.Element(\"track\", id=str(track_id), label=\"Grevy\", source=\"manual\")\n",
+    "\n",
+    "    for frame_id in annotated[track_id].keys():\n",
+    "        if frame_id == sorted(annotated[track_id].keys())[-1]:\n",
+    "            outside = \"1\"\n",
+    "        else:\n",
+    "            outside = \"0\"\n",
+    "\n",
+    "        xml_box = etree.Element(\"box\", frame=str(frame_id), outside=outside, occluded=\"0\",\n",
+    "                                keyframe=str(annotated[track_id][frame_id][4]),\n",
+    "                                xtl=f\"{annotated[track_id][frame_id][0]:.2f}\",\n",
+    "                                ytl=f\"{annotated[track_id][frame_id][1]:.2f}\",\n",
+    "                                xbr=f\"{annotated[track_id][frame_id][2]:.2f}\",\n",
+    "                                ybr=f\"{annotated[track_id][frame_id][3]:.2f}\", z_order=\"0\")\n",
+    "\n",
+    "        xml_track.append(xml_box)\n",
+    "\n",
+    "    if len(annotated[track_id].keys()) > 0:\n",
+    "        xml_page.append(xml_track)\n",
+    "\n",
+    "\n",
+    "# # Parse the original XML file\n",
+    "# original_tree = etree.parse(annotation_path)\n",
+    "# original_root = original_tree.getroot()\n",
+    "\n",
+    "# # Extract the 'meta' element\n",
+    "# meta = original_root.find('meta')\n",
+    "\n",
+    "# # Append 'meta' to the new XML document\n",
+    "# xml_page.append(meta)\n",
+    "\n",
+    "xml_document = etree.ElementTree(xml_page)\n",
+    "\n",
+    "xml_document.write(f\"{tracks_location}/tracks_.xml\", xml_declaration=True, pretty_print=True, encoding=\"utf-8\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a41a25df",
+   "metadata": {},
+   "source": [
+    "# Extract tracks with KABR tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "157201bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/fs/ess/PAS2136/Kenya-2023/Zebras/session_data/18_01_2023_session_7/drone//videos/DJI_0068.MP4/DJI_0068.MP4 | /fs/ess/PAS2136/Kenya-2023/Zebras/methods_paper_analysis/annotation_process/tracks//tracks_.xml -> mini-scenes/videos|DJI_0068.MP4|DJI_0068\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/5806 [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.system(f\"python3 /fs/ess/PAS2136/Kenya-2023/Zebras/methods_paper_analysis/annotation_process/kabr-tools/tracks_extractor.py {video_path}/{video}.MP4 {tracks_location}/tracks_.xml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e8c47fc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ml",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/helper_scripts/downgrade.sh
+++ b/helper_scripts/downgrade.sh
@@ -1,0 +1,24 @@
+# reduce the quality of all mp4 files in a directory
+# usage: ./downgrade.sh /path/to/videos
+
+# get the path to the videos
+path=$1
+
+# get the videos in the path
+videos=$(ls $path)
+
+for video in $videos
+do
+    # downgrade the video
+    ffmpeg -i $path/$video -vf scale=1824:1026 $path/downgraded-$video
+done
+
+# original size: 5472 x 3078
+# 1/2 size: 2736 x 1539
+# 1/3 size: 1824 x 1026
+# 1/4 size: 1368 x 769
+# 1/8 size: 684 x 384 (tried 8.55 which is 640:360, but too blurry)
+# ffprobe -v error -select_streams v:0 -show_entries stream=bit_rate -of default=noprint_wrappers=1:nokey=1 kabr_videos-18_01_2023_session_7-DJI_0068.MP4
+
+# downgraded-kabr_videos-20_01_2023_session_3-DJI_0148
+# kabr_videos-21_01_2023_session_5

--- a/helper_scripts/rename.sh
+++ b/helper_scripts/rename.sh
@@ -1,0 +1,19 @@
+# rename video names with date and species from filepath
+# Usage: ./rename.sh /path/to/videos
+
+# get the path to the videos
+path=$1
+
+# get the date and species from the path
+date=$(echo $path | cut -d'/' -f4)
+species=$(echo $path | cut -d'/' -f5)
+
+# get the videos in the path
+videos=$(ls $path)
+
+# rename the videos
+for video in $videos
+do
+    # rename the video
+    mv $path/$video $path/$date-$species-$video
+done


### PR DESCRIPTION
- Added shell scripts used to manage video files: one to rename files with metadata, including date, session, and species; and one to shrink the video resolution
- Added jupyter notebook to clean CVAT annotations and scale tracks up to OG resolution to create mini-scenes 