### PR TITLE
Add v2.0.0 release commit hash

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ identifiers:
     value: "https://github.com/Imageomics/kabr-tools/releases/tag/v2.0.0"
   - description: "The GitHub URL of the commit tagged with v2.0.0."
     type: url
-    value: "https://github.com/Imageomics/kabr-tools/tree/ " # add commit hash on release
+    value: "https://github.com/Imageomics/kabr-tools/tree/149b66d15fb73c5678fad1c096bc577b5dcbd346"
 keywords:
   - imageomics
   - zebra


### PR DESCRIPTION
Adds commit hash for the v2.0.0 release to the `CITATION.cff`.