### PR TITLE
Remove extra lines

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,12 +46,3 @@ title: "KABR Tools"
 version: 2.0.0
 doi: 10.5281/zenodo.11288083
 type: software
-    - family-names: Zhong
-      given-names: Alison
-    - family-names: Campolongo
-      given-names: Elizabeth
-  title: "KABR Tools"
-  year: 2025
-  version: 1.2.0
-  repository-code: "https://github.com/Imageomics/kabr-tools"
- 


### PR DESCRIPTION
Partial author list wound up at the end of the `CITATION.cff` file, removed that so it renders correctly.

<img width="484" height="372" alt="Screenshot 2025-07-23 at 1 53 39 PM" src="https://github.com/user-attachments/assets/dc0e2579-efe5-4b41-b688-9e7c7ebb04ca" />

There's also an issue with the Zenodo update we'll need to resolve.