### PR TITLE
Pre-release update

### DIFF
--- a/.github/workflows/validate-zenodo.yaml
+++ b/.github/workflows/validate-zenodo.yaml
@@ -1,0 +1,23 @@
+name: Check zenodo metadata
+
+on:
+    push:
+        paths:
+          - '.zenodo.json'
+          - '.github/workflows/validate-zenodo.yaml'
+
+jobs:
+  check-zenodo-metadata:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install zenodraft@0.14.1
+      - name: Check .zenodo.json file
+        run: |
+          npx zenodraft metadata validate .zenodo.json 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,53 @@
+{
+    "creators": [
+      {
+          "name": "Kline, Jenna",
+          "orcid": "0009-0006-7301-5774",
+          "affiliation": "The Ohio State University"
+      },
+      {
+          "name": "Zhong, Alison",
+          "affiliation": "The Ohio State University"
+      },
+      {
+            "name": "Kholiavchenko, Maksim",
+            "orcid": "0000-0001-6757-1957",
+            "affiliation": "Rensselaer Polytechnic Institute"
+      },
+      {
+          "name": "Campolongo, Elizabeth",
+          "orcid": "0000-0003-0846-2413",
+          "affiliation": "The Ohio State University"
+      }
+    ],
+    "description": "Tools for working with data for annotating animal behavior. These were specifically designed during construction of the KABR dataset.",
+    "keywords": [
+      "imageomics",
+      "zebra",
+      "giraffe",
+      "plains zebra",
+      "Grevy's zebra",
+      "video",
+      "animal behavior",
+      "behavior recognition",
+      "annotation",
+      "annotated video",
+      "conservation",
+      "drone",
+      "UAV",
+      "imbalanced",
+      "Kenya",
+      "Mpala Research Centre",
+      "CVAT",
+      "SlowFast"
+    ],
+    "title": "KABR Tools",
+    "version": "2.0.1",
+    "license": "CC0-1.0",
+    "publication_date": "2025-09-26",
+    "grants": [
+        {
+            "id": "021nxhr62::2118240"
+        }
+    ] 
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -43,7 +43,7 @@
     ],
     "title": "KABR Tools",
     "version": "2.0.1",
-    "license": "CC0-1.0",
+    "license": "MIT",
     "publication_date": "2025-09-26",
     "grants": [
         {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,14 +12,14 @@ authors:
   given-names: Elizabeth
   orcid: "https://orcid.org/0000-0003-0846-2413"
 cff-version: 1.2.0
-date-released: "2025-06-17"
+date-released: "2025-09-26"
 identifiers:
-  - description: "The GitHub release URL of tag v2.0.0."
+  - description: "The GitHub release URL of tag v2.0.1."
     type: url
-    value: "https://github.com/Imageomics/kabr-tools/releases/tag/v2.0.0"
-  - description: "The GitHub URL of the commit tagged with v2.0.0."
+    value: "https://github.com/Imageomics/kabr-tools/releases/tag/v2.0.1"
+  - description: "The GitHub URL of the commit tagged with v2.0.1."
     type: url
-    value: "https://github.com/Imageomics/kabr-tools/tree/149b66d15fb73c5678fad1c096bc577b5dcbd346"
+    value: "https://github.com/Imageomics/kabr-tools/tree/<commit-hash>" # update on release
 keywords:
   - imageomics
   - zebra
@@ -43,6 +43,6 @@ license: MIT
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/Imageomics/kabr-tools"
 title: "KABR Tools"
-version: 2.0.0
+version: 2.0.1
 doi: 10.5281/zenodo.11288083
 type: software


### PR DESCRIPTION
Also adds `.zenodo.json` to maintain metadata (e.g., grant info) in the record on syncs. Adds a test to validate this file.

Note, I just cancelled workflow run for [224cebe](224cebe08e608b51a19d6f2131beb47635bdbec3), it didn't really fail.