### PR TITLE
Docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ Please refer to our papers for details on the data collection process and machin
 - [KABR: In-Situ Dataset for Kenyan Animal Behavior Recognition](https://openaccess.thecvf.com/content/WACV2024W/CV4Smalls/papers/Kholiavchenko_KABR_In-Situ_Dataset_for_Kenyan_Animal_Behavior_Recognition_From_Drone_WACVW_2024_paper.pdf) 
 - [Deep dive into KABR: a dataset for understanding ungulate behavior from in-situ drone video](https://link.springer.com/article/10.1007/s11042-024-20512-4) 
 - [Integrating Biological Data into Autonomous Remote Sensing Systems for In Situ Imageomics: A Case Study for Kenyan Animal Behavior Sensing with Unmanned Aerial Vehicles (UAVs)](https://arxiv.org/abs/2407.16864)
+- [A Framework for Autonomic Computing for In Situ Imageomics](https://ieeexplore.ieee.org/abstract/document/10336017)
 
 ## Citation
 
-If you use this toolkit in your research, please cite:
+If you use this toolkit in your research, please cite both this package and the associated paper:
 
+**Package citation:**
 ```bibtex
 @software{kabr-tools,
   author = {Kline, Jenna and Zhong, Alison and Campolongo, Elizabeth and Kholiavchenko, Maksim},
@@ -108,6 +110,10 @@ If you use this toolkit in your research, please cite:
   doi = {10.5281/zenodo.11288083},
   url = {https://github.com/Imageomics/kabr-tools}
 }
+```
+
+**Paper citation:**
+```bibtex
 ```
 
 ## 💬 Feedback & Issues

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,7 @@
+This work was supported by the [Imageomics Institute](https://imageomics.org), which is funded by the US National Science Foundation's Harnessing the Data Revolution (HDR) program under [Award #2118240](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2118240) (Imageomics: A New Frontier of Biological Information Powered by Knowledge-Guided Machine Learning). Additional support was provided by the [AI Institute for Intelligent Cyberinfrastructure with Computational Learning in the Environment (ICICLE)](https://icicle.osu.edu/), funded by the US National Science Foundation under [Award #2112606](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2112606).
+ 
+
+Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+
+ 
+The [raw data](https://huggingface.co/datasets/imageomics/KABR-raw-videoss) fed into the [KABR tools pipeline](https://github.com/Imageomics/kabr-tools) to produce this worked example was collected at the [Mpala Research Centre](https://mpala.org/) in Kenya, in accordance with Research License No. NACOSTI/P/22/18214. The data collection protocol adhered strictly to the guidelines set forth by the Institutional Animal Care and Use Committee under permission No. IACUC 1835F.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The KABR tools used in this process can be installed with:
 
 ```bash
 pip install torch torchvision
-pip install git+https://github.com/Imageomics/kabr-tools-paper
+pip install git+https://github.com/Imageomics/kabr-tools
 ```
 
 !!! note "PyTorch Installation"
@@ -51,14 +51,11 @@ To get started with KABR tools, follow the pipeline steps in order:
 
 ## Additional Resources
 
-- [KABR Project Page](https://kabrdata.xyz/) for additional details on the dataset and original paper
-- [KABR Dataset on Hugging Face](https://huggingface.co/datasets/imageomics/KABR)
-- [Pre-trained Models](https://huggingface.co/imageomics/x3d-kabr-kinetics)
+- [KABR Project Page](https://imageomics.github.io/KABR/) for additional details on the dataset and original paper.
+- [KABR Mini-Scene Dataset on Hugging Face](https://huggingface.co/datasets/imageomics/KABR)
+- [Pre-trained Model](https://huggingface.co/imageomics/x3d-kabr-kinetics)
+- [KABR Collection on Hugging Face](https://huggingface.co/collections/imageomics/kabr-664dff304d29e6cd7b8e1a00): All datasets and models associated to the KABR Project.
 
 ## Citation
 
-If you use KABR tools in your research, please cite our papers:
-
-- [KABR: In-Situ Dataset for Kenyan Animal Behavior Recognition from Drone Videos](https://openaccess.thecvf.com/content/WACV2024W/CV4Smalls/papers/Kholiavchenko_KABR_In-Situ_Dataset_for_Kenyan_Animal_Behavior_Recognition_From_Drone_WACVW_2024_paper.pdf)
-- [A Framework for Autonomic Computing for In Situ Imageomics](https://ieeexplore.ieee.org/abstract/document/10336017)
-- [Integrating Biological Data into Autonomous Remote Sensing Systems for In Situ Imageomics](https://arxiv.org/abs/2407.16864)
+If you use KABR tools in your research, please follow the [citation guidance in the repo](https://github.com/Imageomics/kabr-tools?tab=readme-ov-file#citation).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - "Linear Regression": case_studies/1_grevys_landscape/grevys_landscape_lr.ipynb
     - "2: Zebra Behavior Transitions": case_studies/2_zebra_transition/behaviortransitionsheatmap.ipynb
     - "3: Mixed Species Social": case_studies/3_mixed_species_social/mixed_species_overlap.ipynb
+  - Acknowledgements: acknowledgements.md
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: KABR Tools Documentation
 site_description: Tools for working with data for annotating animal behavior
-site_author: KABR Team
-site_url: https://imageomics.github.io/kabr-tools-paper
+site_author: Imageomics KABR Team
+site_url: https://imageomics.github.io/kabr-tools
 
-repo_name: Imageomics/kabr-tools-paper
-repo_url: https://github.com/Imageomics/kabr-tools-paper
+repo_name: Imageomics/kabr-tools
+repo_url: https://github.com/Imageomics/kabr-tools
 edit_uri: edit/main/docs/
 
 theme:
@@ -114,4 +114,4 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/Imageomics/kabr-tools-paper
+      link: https://github.com/Imageomics/kabr-tools


### PR DESCRIPTION
Corrects URLs for MkDocs site (removes `-paper`), adds acknowledgements page, clarify some refs to avoid duplication.

Progress toward [refinement/cleanup issue](https://github.com/Imageomics/kabr-tools-paper/issues/14).