### PR TITLE
Add test_yolo.py to detector2cvat workflow

### DIFF
--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -36,4 +36,5 @@ jobs:
         mkdir /tmp/test
         cd /tmp/test
         python -m unittest discover -s "$GITHUB_WORKSPACE/tests" -p "test_detector2cvat.py" -t "$GITHUB_WORKSPACE"
+        python -m unittest discover -s "$GITHUB_WORKSPACE/tests" -p "test_yolo.py" -t "$GITHUB_WORKSPACE"
 


### PR DESCRIPTION
Closes #122

Adds `test_yolo.py` to the `detector2cvat` workflow since it tests a dependency of `detector2cvat.py`.