### PR TITLE
feat: Narrow workflow path filters to tool-specific files

### DIFF
--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -8,7 +8,7 @@ on:
       - 'LICENSE'
       - 'CITATION.cff'
       - 'mkdocs.yml'
-      - 'config.yml'
+      - '.gitignore'
       - '.zenodo.json'
       - 'docs/**'
       - 'cvat_templates/**'

--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -5,8 +5,14 @@ on:
     paths:
       - 'src/kabr_tools/cvat2slowfast.py'
       - 'src/kabr_tools/utils/path.py'
+      - 'src/kabr_tools/__init__.py'
       - 'tests/test_cvat2slowfast.py'
+      - 'tests/test_tracks_extractor.py'
       - 'tests/utils.py'
+      - 'ethogram/classes.json'
+      - 'ethogram/old2new.json'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/cvat2slowfast.yml'
 
 jobs:

--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -14,6 +14,19 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/cvat2slowfast.yml'
+  pull_request:
+    paths:
+      - 'src/kabr_tools/cvat2slowfast.py'
+      - 'src/kabr_tools/utils/path.py'
+      - 'src/kabr_tools/__init__.py'
+      - 'tests/test_cvat2slowfast.py'
+      - 'tests/test_tracks_extractor.py'
+      - 'tests/utils.py'
+      - 'ethogram/classes.json'
+      - 'ethogram/old2new.json'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/cvat2slowfast.yml'
 
 jobs:
   build:

--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -1,19 +1,6 @@
 name: cvat2slowfast test
 
 on:
-  push:
-    paths:
-      - 'src/kabr_tools/cvat2slowfast.py'
-      - 'src/kabr_tools/utils/path.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_cvat2slowfast.py'
-      - 'tests/test_tracks_extractor.py'
-      - 'tests/utils.py'
-      - 'ethogram/classes.json'
-      - 'ethogram/old2new.json'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/cvat2slowfast.yml'
   pull_request:
     paths:
       - 'src/kabr_tools/cvat2slowfast.py'

--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -2,18 +2,45 @@ name: cvat2slowfast test
 
 on:
   pull_request:
-    paths:
-      - 'src/kabr_tools/cvat2slowfast.py'
-      - 'src/kabr_tools/utils/path.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_cvat2slowfast.py'
-      - 'tests/test_tracks_extractor.py'
-      - 'tests/utils.py'
-      - 'ethogram/classes.json'
-      - 'ethogram/old2new.json'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/cvat2slowfast.yml'
+    paths-ignore:
+      # docs and metadata
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'mkdocs.yml'
+      - 'config.yml'
+      - '.zenodo.json'
+      - 'docs/**'
+      - 'cvat_templates/**'
+      - 'helper_scripts/**'
+      - 'utils/**'
+      - '.github/workflows/deploy-docs.yaml'
+      - '.github/workflows/validate-zenodo.yaml'
+      # sibling test workflows
+      - '.github/workflows/cvat2ultralytics.yml'
+      - '.github/workflows/detector2cvat.yml'
+      - '.github/workflows/miniscene2behavior.yml'
+      - '.github/workflows/player.yml'
+      - '.github/workflows/tracks_extractor.yml'
+      # other tool source files
+      - 'src/kabr_tools/cvat2ultralytics.py'
+      - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/detector2cvat.py'
+      - 'src/kabr_tools/miniscene2behavior.py'
+      # utils
+      - 'src/kabr_tools/utils/yolo.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      # ethogram files
+      - 'ethogram/label2index.json'
+      - 'ethogram/yolo_labels.json'
+      - 'ethogram/yolo_equiv.json'
+      # other test files
+      - 'tests/test_cvat2ultralytics.py'
+      - 'tests/test_player.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/test_yolo.py'
+      - 'tests/examples/**'
 
 jobs:
   build:

--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -3,8 +3,10 @@ name: cvat2slowfast test
 on:
   push:
     paths:
-      - 'src/**'
-      - 'tests/**'
+      - 'src/kabr_tools/cvat2slowfast.py'
+      - 'src/kabr_tools/utils/path.py'
+      - 'tests/test_cvat2slowfast.py'
+      - 'tests/utils.py'
       - '.github/workflows/cvat2slowfast.yml'
 
 jobs:

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -1,16 +1,6 @@
 name: cvat2ultralytics test
 
 on:
-  push:
-    paths:
-      - 'src/kabr_tools/cvat2ultralytics.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_cvat2ultralytics.py'
-      - 'tests/utils.py'
-      - 'ethogram/label2index.json'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/cvat2ultralytics.yml'
   pull_request:
     paths:
       - 'src/kabr_tools/cvat2ultralytics.py'

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -8,7 +8,7 @@ on:
       - 'LICENSE'
       - 'CITATION.cff'
       - 'mkdocs.yml'
-      - 'config.yml'
+      - '.gitignore'
       - '.zenodo.json'
       - 'docs/**'
       - 'cvat_templates/**'

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -2,15 +2,48 @@ name: cvat2ultralytics test
 
 on:
   pull_request:
-    paths:
-      - 'src/kabr_tools/cvat2ultralytics.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_cvat2ultralytics.py'
-      - 'tests/utils.py'
-      - 'ethogram/label2index.json'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/cvat2ultralytics.yml'
+    paths-ignore:
+      # docs and metadata
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'mkdocs.yml'
+      - 'config.yml'
+      - '.zenodo.json'
+      - 'docs/**'
+      - 'cvat_templates/**'
+      - 'helper_scripts/**'
+      - 'utils/**'
+      - '.github/workflows/deploy-docs.yaml'
+      - '.github/workflows/validate-zenodo.yaml'
+      # sibling test workflows
+      - '.github/workflows/cvat2slowfast.yml'
+      - '.github/workflows/detector2cvat.yml'
+      - '.github/workflows/miniscene2behavior.yml'
+      - '.github/workflows/player.yml'
+      - '.github/workflows/tracks_extractor.yml'
+      # other tool source files
+      - 'src/kabr_tools/cvat2slowfast.py'
+      - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/detector2cvat.py'
+      - 'src/kabr_tools/miniscene2behavior.py'
+      - 'src/kabr_tools/tracks_extractor.py'
+      # utils
+      - 'src/kabr_tools/utils/yolo.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      # ethogram files
+      - 'ethogram/classes.json'
+      - 'ethogram/old2new.json'
+      - 'ethogram/yolo_labels.json'
+      - 'ethogram/yolo_equiv.json'
+      # other test files
+      - 'tests/test_cvat2slowfast.py'
+      - 'tests/test_player.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/test_tracks_extractor.py'
+      - 'tests/test_yolo.py'
+      - 'tests/examples/**'
 
 jobs:
   build:

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -4,8 +4,12 @@ on:
   push:
     paths:
       - 'src/kabr_tools/cvat2ultralytics.py'
+      - 'src/kabr_tools/__init__.py'
       - 'tests/test_cvat2ultralytics.py'
       - 'tests/utils.py'
+      - 'ethogram/label2index.json'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/cvat2ultralytics.yml'
 
 jobs:

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -11,6 +11,16 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/cvat2ultralytics.yml'
+  pull_request:
+    paths:
+      - 'src/kabr_tools/cvat2ultralytics.py'
+      - 'src/kabr_tools/__init__.py'
+      - 'tests/test_cvat2ultralytics.py'
+      - 'tests/utils.py'
+      - 'ethogram/label2index.json'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/cvat2ultralytics.yml'
 
 jobs:
   build:

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -3,8 +3,9 @@ name: cvat2ultralytics test
 on:
   push:
     paths:
-      - 'src/**'
-      - 'tests/**'
+      - 'src/kabr_tools/cvat2ultralytics.py'
+      - 'tests/test_cvat2ultralytics.py'
+      - 'tests/utils.py'
       - '.github/workflows/cvat2ultralytics.yml'
 
 jobs:

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -8,7 +8,7 @@ on:
       - 'LICENSE'
       - 'CITATION.cff'
       - 'mkdocs.yml'
-      - 'config.yml'
+      - '.gitignore'
       - '.zenodo.json'
       - 'docs/**'
       - 'cvat_templates/**'

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -1,23 +1,6 @@
 name: detector2cvat test
 
 on:
-  push:
-    paths:
-      - 'src/kabr_tools/detector2cvat.py'
-      - 'src/kabr_tools/utils/yolo.py'
-      - 'src/kabr_tools/utils/tracker.py'
-      - 'src/kabr_tools/utils/object.py'
-      - 'src/kabr_tools/utils/draw.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_detector2cvat.py'
-      - 'tests/test_yolo.py'
-      - 'tests/utils.py'
-      - 'tests/examples/**'
-      - 'ethogram/yolo_labels.json'
-      - 'ethogram/yolo_equiv.json'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/detector2cvat.yml'
   pull_request:
     paths:
       - 'src/kabr_tools/detector2cvat.py'

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -2,22 +2,45 @@ name: detector2cvat test
 
 on:
   pull_request:
-    paths:
-      - 'src/kabr_tools/detector2cvat.py'
-      - 'src/kabr_tools/utils/yolo.py'
-      - 'src/kabr_tools/utils/tracker.py'
-      - 'src/kabr_tools/utils/object.py'
-      - 'src/kabr_tools/utils/draw.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_detector2cvat.py'
-      - 'tests/test_yolo.py'
-      - 'tests/utils.py'
-      - 'tests/examples/**'
-      - 'ethogram/yolo_labels.json'
-      - 'ethogram/yolo_equiv.json'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/detector2cvat.yml'
+    paths-ignore:
+      # docs and metadata
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'mkdocs.yml'
+      - 'config.yml'
+      - '.zenodo.json'
+      - 'docs/**'
+      - 'cvat_templates/**'
+      - 'helper_scripts/**'
+      - 'utils/**'
+      - '.github/workflows/deploy-docs.yaml'
+      - '.github/workflows/validate-zenodo.yaml'
+      # sibling test workflows
+      - '.github/workflows/cvat2slowfast.yml'
+      - '.github/workflows/cvat2ultralytics.yml'
+      - '.github/workflows/miniscene2behavior.yml'
+      - '.github/workflows/player.yml'
+      - '.github/workflows/tracks_extractor.yml'
+      # other tool source files
+      - 'src/kabr_tools/cvat*.py'
+      - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/miniscene2behavior.py'
+      - 'src/kabr_tools/tracks_extractor.py'
+      # utils
+      - 'src/kabr_tools/utils/path.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      - 'src/kabr_tools/utils/utils.py'
+      - 'src/kabr_tools/utils/detector.py'
+      # ethogram files
+      - 'ethogram/classes.json'
+      - 'ethogram/old2new.json'
+      - 'ethogram/label2index.json'
+      # other test files
+      - 'tests/test_cvat*.py'
+      - 'tests/test_player.py'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/test_tracks_extractor.py'
 
 jobs:
   build:

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -3,8 +3,14 @@ name: detector2cvat test
 on:
   push:
     paths:
-      - 'src/**'
-      - 'tests/**'
+      - 'src/kabr_tools/detector2cvat.py'
+      - 'src/kabr_tools/utils/yolo.py'
+      - 'src/kabr_tools/utils/tracker.py'
+      - 'src/kabr_tools/utils/object.py'
+      - 'src/kabr_tools/utils/draw.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_yolo.py'
+      - 'tests/utils.py'
       - '.github/workflows/detector2cvat.yml'
 
 jobs:

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -18,6 +18,23 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/detector2cvat.yml'
+  pull_request:
+    paths:
+      - 'src/kabr_tools/detector2cvat.py'
+      - 'src/kabr_tools/utils/yolo.py'
+      - 'src/kabr_tools/utils/tracker.py'
+      - 'src/kabr_tools/utils/object.py'
+      - 'src/kabr_tools/utils/draw.py'
+      - 'src/kabr_tools/__init__.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_yolo.py'
+      - 'tests/utils.py'
+      - 'tests/examples/**'
+      - 'ethogram/yolo_labels.json'
+      - 'ethogram/yolo_equiv.json'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/detector2cvat.yml'
 
 jobs:
   build:

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -8,9 +8,15 @@ on:
       - 'src/kabr_tools/utils/tracker.py'
       - 'src/kabr_tools/utils/object.py'
       - 'src/kabr_tools/utils/draw.py'
+      - 'src/kabr_tools/__init__.py'
       - 'tests/test_detector2cvat.py'
       - 'tests/test_yolo.py'
       - 'tests/utils.py'
+      - 'tests/examples/**'
+      - 'ethogram/yolo_labels.json'
+      - 'ethogram/yolo_equiv.json'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/detector2cvat.yml'
 
 jobs:

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -2,22 +2,39 @@ name: miniscene2behavior test
 
 on:
   pull_request:
-    paths:
-      - 'src/kabr_tools/miniscene2behavior.py'
-      - 'src/kabr_tools/tracks_extractor.py'
-      - 'src/kabr_tools/utils/slowfast/**'
-      - 'src/kabr_tools/utils/utils.py'
-      - 'src/kabr_tools/utils/detector.py'
-      - 'src/kabr_tools/utils/tracker.py'
-      - 'src/kabr_tools/utils/object.py'
-      - 'src/kabr_tools/utils/draw.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_miniscene2behavior.py'
-      - 'tests/utils.py'
-      - 'tests/examples/**'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/miniscene2behavior.yml'
+    paths-ignore:
+      # docs and metadata
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'mkdocs.yml'
+      - 'config.yml'
+      - '.zenodo.json'
+      - 'docs/**'
+      - 'cvat_templates/**'
+      - 'helper_scripts/**'
+      - 'utils/**'
+      - '.github/workflows/deploy-docs.yaml'
+      - '.github/workflows/validate-zenodo.yaml'
+      # sibling test workflows
+      - '.github/workflows/cvat2slowfast.yml'
+      - '.github/workflows/cvat2ultralytics.yml'
+      - '.github/workflows/detector2cvat.yml'
+      - '.github/workflows/player.yml'
+      - '.github/workflows/tracks_extractor.yml'
+      # other tool source files
+      - 'src/kabr_tools/cvat*.py'
+      - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/detector2cvat.py'
+      # utils
+      - 'src/kabr_tools/utils/path.py'
+      - 'src/kabr_tools/utils/yolo.py'
+      # other test files
+      - 'tests/test_cvat*.py'
+      - 'tests/test_player.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_tracks_extractor.py'
+      - 'tests/test_yolo.py'
 
 jobs:
   build:

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -8,7 +8,7 @@ on:
       - 'LICENSE'
       - 'CITATION.cff'
       - 'mkdocs.yml'
-      - 'config.yml'
+      - '.gitignore'
       - '.zenodo.json'
       - 'docs/**'
       - 'cvat_templates/**'

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -3,8 +3,10 @@ name: miniscene2behavior test
 on:
   push:
     paths:
-      - 'src/**'
-      - 'tests/**'
+      - 'src/kabr_tools/miniscene2behavior.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/utils.py'
       - '.github/workflows/miniscene2behavior.yml'
 
 jobs:

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -4,9 +4,18 @@ on:
   push:
     paths:
       - 'src/kabr_tools/miniscene2behavior.py'
+      - 'src/kabr_tools/tracks_extractor.py'
       - 'src/kabr_tools/utils/slowfast/**'
+      - 'src/kabr_tools/utils/utils.py'
+      - 'src/kabr_tools/utils/detector.py'
+      - 'src/kabr_tools/utils/tracker.py'
+      - 'src/kabr_tools/utils/object.py'
+      - 'src/kabr_tools/utils/draw.py'
+      - 'src/kabr_tools/__init__.py'
       - 'tests/test_miniscene2behavior.py'
       - 'tests/utils.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/miniscene2behavior.yml'
 
 jobs:

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -18,6 +18,23 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/miniscene2behavior.yml'
+  pull_request:
+    paths:
+      - 'src/kabr_tools/miniscene2behavior.py'
+      - 'src/kabr_tools/tracks_extractor.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      - 'src/kabr_tools/utils/utils.py'
+      - 'src/kabr_tools/utils/detector.py'
+      - 'src/kabr_tools/utils/tracker.py'
+      - 'src/kabr_tools/utils/object.py'
+      - 'src/kabr_tools/utils/draw.py'
+      - 'src/kabr_tools/__init__.py'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/utils.py'
+      - 'tests/examples/**'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/miniscene2behavior.yml'
 
 jobs:
   build:

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -14,6 +14,7 @@ on:
       - 'src/kabr_tools/__init__.py'
       - 'tests/test_miniscene2behavior.py'
       - 'tests/utils.py'
+      - 'tests/examples/**'
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/miniscene2behavior.yml'

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -1,23 +1,6 @@
 name: miniscene2behavior test
 
 on:
-  push:
-    paths:
-      - 'src/kabr_tools/miniscene2behavior.py'
-      - 'src/kabr_tools/tracks_extractor.py'
-      - 'src/kabr_tools/utils/slowfast/**'
-      - 'src/kabr_tools/utils/utils.py'
-      - 'src/kabr_tools/utils/detector.py'
-      - 'src/kabr_tools/utils/tracker.py'
-      - 'src/kabr_tools/utils/object.py'
-      - 'src/kabr_tools/utils/draw.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_miniscene2behavior.py'
-      - 'tests/utils.py'
-      - 'tests/examples/**'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/miniscene2behavior.yml'
   pull_request:
     paths:
       - 'src/kabr_tools/miniscene2behavior.py'

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -8,7 +8,7 @@ on:
       - 'LICENSE'
       - 'CITATION.cff'
       - 'mkdocs.yml'
-      - 'config.yml'
+      - '.gitignore'
       - '.zenodo.json'
       - 'docs/**'
       - 'cvat_templates/**'

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -1,15 +1,6 @@
 name: player test
 
 on:
-  push:
-    paths:
-      - 'src/kabr_tools/player.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_player.py'
-      - 'tests/utils.py'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/player.yml'
   pull_request:
     paths:
       - 'src/kabr_tools/player.py'

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -2,14 +2,43 @@ name: player test
 
 on:
   pull_request:
-    paths:
-      - 'src/kabr_tools/player.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_player.py'
-      - 'tests/utils.py'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/player.yml'
+    paths-ignore:
+      # docs and metadata
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'mkdocs.yml'
+      - 'config.yml'
+      - '.zenodo.json'
+      - 'docs/**'
+      - 'cvat_templates/**'
+      - 'helper_scripts/**'
+      - 'utils/**'
+      - '.github/workflows/deploy-docs.yaml'
+      - '.github/workflows/validate-zenodo.yaml'
+      # sibling test workflows
+      - '.github/workflows/cvat2slowfast.yml'
+      - '.github/workflows/cvat2ultralytics.yml'
+      - '.github/workflows/detector2cvat.yml'
+      - '.github/workflows/miniscene2behavior.yml'
+      - '.github/workflows/tracks_extractor.yml'
+      # other tool source files
+      - 'src/kabr_tools/cvat*.py'
+      - 'src/kabr_tools/detector2cvat.py'
+      - 'src/kabr_tools/miniscene2behavior.py'
+      - 'src/kabr_tools/tracks_extractor.py'
+      # utils
+      - 'src/kabr_tools/utils/yolo.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      # ethogram files
+      - 'ethogram/**'
+      # other test files
+      - 'tests/test_cvat*.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/test_tracks_extractor.py'
+      - 'tests/test_yolo.py'
+      - 'tests/examples/**'
 
 jobs:
   build:

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -10,6 +10,15 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/player.yml'
+  pull_request:
+    paths:
+      - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/__init__.py'
+      - 'tests/test_player.py'
+      - 'tests/utils.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/player.yml'
 
 jobs:
   build:

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -3,8 +3,9 @@ name: player test
 on:
   push:
     paths:
-      - 'src/**'
-      - 'tests/**'
+      - 'src/kabr_tools/player.py'
+      - 'tests/test_player.py'
+      - 'tests/utils.py'
       - '.github/workflows/player.yml'
 
 jobs:

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -4,8 +4,11 @@ on:
   push:
     paths:
       - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/__init__.py'
       - 'tests/test_player.py'
       - 'tests/utils.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/player.yml'
 
 jobs:

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -3,8 +3,14 @@ name: tracks_extractor test
 on:
   push:
     paths:
-      - 'src/**'
-      - 'tests/**'
+      - 'src/kabr_tools/tracks_extractor.py'
+      - 'src/kabr_tools/utils/utils.py'
+      - 'src/kabr_tools/utils/detector.py'
+      - 'src/kabr_tools/utils/tracker.py'
+      - 'src/kabr_tools/utils/object.py'
+      - 'src/kabr_tools/utils/draw.py'
+      - 'tests/test_tracks_extractor.py'
+      - 'tests/utils.py'
       - '.github/workflows/tracks_extractor.yml'
 
 jobs:

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -8,7 +8,7 @@ on:
       - 'LICENSE'
       - 'CITATION.cff'
       - 'mkdocs.yml'
-      - 'config.yml'
+      - '.gitignore'
       - '.zenodo.json'
       - 'docs/**'
       - 'cvat_templates/**'

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -1,20 +1,6 @@
 name: tracks_extractor test
 
 on:
-  push:
-    paths:
-      - 'src/kabr_tools/tracks_extractor.py'
-      - 'src/kabr_tools/utils/utils.py'
-      - 'src/kabr_tools/utils/detector.py'
-      - 'src/kabr_tools/utils/tracker.py'
-      - 'src/kabr_tools/utils/object.py'
-      - 'src/kabr_tools/utils/draw.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_tracks_extractor.py'
-      - 'tests/utils.py'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/tracks_extractor.yml'
   pull_request:
     paths:
       - 'src/kabr_tools/tracks_extractor.py'

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -2,19 +2,43 @@ name: tracks_extractor test
 
 on:
   pull_request:
-    paths:
-      - 'src/kabr_tools/tracks_extractor.py'
-      - 'src/kabr_tools/utils/utils.py'
-      - 'src/kabr_tools/utils/detector.py'
-      - 'src/kabr_tools/utils/tracker.py'
-      - 'src/kabr_tools/utils/object.py'
-      - 'src/kabr_tools/utils/draw.py'
-      - 'src/kabr_tools/__init__.py'
-      - 'tests/test_tracks_extractor.py'
-      - 'tests/utils.py'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/tracks_extractor.yml'
+    paths-ignore:
+      # docs and metadata
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'mkdocs.yml'
+      - 'config.yml'
+      - '.zenodo.json'
+      - 'docs/**'
+      - 'cvat_templates/**'
+      - 'helper_scripts/**'
+      - 'utils/**'
+      - '.github/workflows/deploy-docs.yaml'
+      - '.github/workflows/validate-zenodo.yaml'
+      # sibling test workflows
+      - '.github/workflows/cvat2slowfast.yml'
+      - '.github/workflows/cvat2ultralytics.yml'
+      - '.github/workflows/detector2cvat.yml'
+      - '.github/workflows/miniscene2behavior.yml'
+      - '.github/workflows/player.yml'
+      # other tool source files
+      - 'src/kabr_tools/cvat*.py'
+      - 'src/kabr_tools/player.py'
+      - 'src/kabr_tools/detector2cvat.py'
+      - 'src/kabr_tools/miniscene2behavior.py'
+      # utils
+      - 'src/kabr_tools/utils/path.py'
+      - 'src/kabr_tools/utils/yolo.py'
+      - 'src/kabr_tools/utils/slowfast/**'
+      # ethogram files
+      - 'ethogram/**'
+      # other test files
+      - 'tests/test_cvat*.py'
+      - 'tests/test_player.py'
+      - 'tests/test_detector2cvat.py'
+      - 'tests/test_miniscene2behavior.py'
+      - 'tests/test_yolo.py'
 
 jobs:
   build:

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -9,8 +9,11 @@ on:
       - 'src/kabr_tools/utils/tracker.py'
       - 'src/kabr_tools/utils/object.py'
       - 'src/kabr_tools/utils/draw.py'
+      - 'src/kabr_tools/__init__.py'
       - 'tests/test_tracks_extractor.py'
       - 'tests/utils.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/tracks_extractor.yml'
 
 jobs:

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -15,6 +15,20 @@ on:
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.github/workflows/tracks_extractor.yml'
+  pull_request:
+    paths:
+      - 'src/kabr_tools/tracks_extractor.py'
+      - 'src/kabr_tools/utils/utils.py'
+      - 'src/kabr_tools/utils/detector.py'
+      - 'src/kabr_tools/utils/tracker.py'
+      - 'src/kabr_tools/utils/object.py'
+      - 'src/kabr_tools/utils/draw.py'
+      - 'src/kabr_tools/__init__.py'
+      - 'tests/test_tracks_extractor.py'
+      - 'tests/utils.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/tracks_extractor.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Each workflow now only triggers when its own source, test, and shared utility files are modified, rather than any change under \`src/**\` or \`tests/**\`.

This PR removes the `push` trigger from all workflows. On `main` currently, workflows run on push, after this merges they will only run on `pull_request` in practice since changes go through PRs this will not have a practical change in when workflows run.

### Testing

In a temp PR I made a single change to the `player.py` and opened a draft PR where we can see below only affected workflows ran.

<img width="951" height="670" alt="image" src="https://github.com/user-attachments/assets/334091d4-b1c1-45d7-98dc-e972c2e5ce73" />


Closes #92