### PR TITLE
Remove macOS from CI test matrices

### DIFF
--- a/.github/workflows/cvat2slowfast.yml
+++ b/.github/workflows/cvat2slowfast.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/cvat2ultralytics.yml
+++ b/.github/workflows/cvat2ultralytics.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/detector2cvat.yml
+++ b/.github/workflows/detector2cvat.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/miniscene2behavior.yml
+++ b/.github/workflows/miniscene2behavior.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/player.yml
+++ b/.github/workflows/player.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/tracks_extractor.yml
+++ b/.github/workflows/tracks_extractor.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary
  - Drops `macos-latest` from the OS matrix in all 6 workflow files
  - Ubuntu is sufficiently similar to macOS to catch the same issues
  - Most users run kabr-tools on shared Linux resources (OSC, lab nodes); Windows retained for its distinct edge cases

  Closes #126