### PR TITLE
bug: Fix player trackbar max to use video frame count

### DIFF
--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -25,7 +25,10 @@ updated: bool = False
 
 def update_trackbar(track_name: str) -> None:
     global index, name
-    max_val = int(vcs[track_name].get(cv2.CAP_PROP_FRAME_COUNT)) - 1
+    frame_count = int(vcs[track_name].get(cv2.CAP_PROP_FRAME_COUNT))
+    if frame_count <= 0:
+        raise ValueError(f"Could not read frame count for '{track_name}'")
+    max_val = frame_count - 1
     cv2.setTrackbarMax(name, "TrackPlayer", max_val)
 
     if index > max_val:
@@ -218,7 +221,10 @@ def player(folder: str, save: bool, show: bool) -> None:
 
     index = 0
     cv2.namedWindow("TrackPlayer")
-    cv2.createTrackbar(name, "TrackPlayer", index, int(vcs["main"].get(cv2.CAP_PROP_FRAME_COUNT)) - 1, on_slider_change)
+    main_frame_count = int(vcs["main"].get(cv2.CAP_PROP_FRAME_COUNT))
+    if main_frame_count <= 0:
+        raise ValueError("Could not read frame count for main video")
+    cv2.createTrackbar(name, "TrackPlayer", index, main_frame_count - 1, on_slider_change)
     current = "main"
     vc = vcs[current]
     target_width = int(vc.get(cv2.CAP_PROP_FRAME_WIDTH))

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -25,7 +25,7 @@ updated: bool = False
 
 def update_trackbar(track_name: str) -> None:
     global index, name
-    max_val = len(metadata["tracks"][track_name]) - 1
+    max_val = int(vcs[track_name].get(cv2.CAP_PROP_FRAME_COUNT)) - 1
     cv2.setTrackbarMax(name, "TrackPlayer", max_val)
 
     if index > max_val:
@@ -222,7 +222,7 @@ def player(folder: str, save: bool, show: bool) -> None:
 
     index = 0
     cv2.namedWindow("TrackPlayer")
-    cv2.createTrackbar(name, "TrackPlayer", index, len(metadata["tracks"]["main"]) - 1, on_slider_change)
+    cv2.createTrackbar(name, "TrackPlayer", index, int(vcs["main"].get(cv2.CAP_PROP_FRAME_COUNT)) - 1, on_slider_change)
     current = "main"
     vc = vcs[current]
     target_width = int(vc.get(cv2.CAP_PROP_FRAME_WIDTH))

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -37,12 +37,13 @@ def on_slider_change(value: int) -> None:
     global index, vcs, current, trackbar_position, paused, updated
     index = value
 
-    if index >= len(metadata["tracks"][current]):
-        index = len(metadata["tracks"][current]) - 1
+    max_val = int(vcs[current].get(cv2.CAP_PROP_FRAME_COUNT)) - 1
+    if index > max_val:
+        index = max_val
         return
 
     if abs(trackbar_position - index) > 10:
-        vcs[current].set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
+        vcs[current].set(cv2.CAP_PROP_POS_FRAMES, index)
 
         if paused:
             updated = True

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -178,7 +178,7 @@ def player(folder: str, save: bool, show: bool) -> None:
     save - bool. Flag to save video.
     show - bool. Flag to display player's visualization.
     """
-    global index, vcs, vc, current, metadata, trackbar_position, paused, updated
+    global index, vcs, vc, current, name, metadata, trackbar_position, paused, updated
     name = Path(folder).name
 
     metadata_path = f"{folder}/metadata/{name}_metadata.json"
@@ -238,6 +238,7 @@ def player(folder: str, save: bool, show: bool) -> None:
             if metadata["tracks"][current][index] < 0:
                 current = "main"
                 vc = vcs[current]
+                update_trackbar(current)
                 vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
 
         returned, frame = vc.read()
@@ -305,6 +306,7 @@ def player(folder: str, save: bool, show: bool) -> None:
             else:
                 current = "main"
                 vc = vcs[current]
+                update_trackbar(current)
                 vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
 
     if save:

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -17,14 +17,29 @@ letter2hotkey: dict = {13: "main", 48: "0", 49: "1", 50: "2", 51: "3",
                        36: "14", 37: "15", 94: "16", 38: "17",
                        42: "18", 40: "19"}
 current: str = "main"
+name: str = ""
 trackbar_position: int = 0
 paused: bool = False
 updated: bool = False
 
 
+def update_trackbar(track_name: str) -> None:
+    global index, name
+    max_val = len(metadata["tracks"][track_name]) - 1
+    cv2.setTrackbarMax(name, "TrackPlayer", max_val)
+
+    if index > max_val:
+        index = max_val
+        cv2.setTrackbarPos(name, "TrackPlayer", index)
+
+
 def on_slider_change(value: int) -> None:
     global index, vcs, current, trackbar_position, paused, updated
     index = value
+
+    if index >= len(metadata["tracks"][current]):
+        index = len(metadata["tracks"][current]) - 1
+        return
 
     if abs(trackbar_position - index) > 10:
         vcs[current].set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -143,7 +143,7 @@ def draw_info(image: MatLike, width: int) -> MatLike:
 
 
 def hotkey(key: int) -> None:
-    global current, metadata, vc, letter2hotkey
+    global current, index, metadata, vc, letter2hotkey
 
     mapped = letter2hotkey[key]
 
@@ -151,22 +151,17 @@ def hotkey(key: int) -> None:
         current = mapped
         vc = vcs[current]
         update_trackbar(current)
-        vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
+        index = int(vc.get(cv2.CAP_PROP_POS_FRAMES))
+        cv2.setTrackbarPos(name, "TrackPlayer", index)
     elif mapped in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
                     "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]:
         if metadata["tracks"].get(mapped) is not None:
-            if metadata["tracks"][mapped][index] != -1:
-                current = mapped
-                vc = vcs[current]
-                update_trackbar(current)
-
-                if index < len(metadata["tracks"][mapped]):
-                    if metadata["tracks"][mapped][index] < 0:
-                        current = "main"
-                        vc = vcs[current]
-                        update_trackbar(current)
-
-                    vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
+            current = mapped
+            vc = vcs[current]
+            update_trackbar(current)
+            index = 0
+            cv2.setTrackbarPos(name, "TrackPlayer", 0)
+            vc.set(cv2.CAP_PROP_POS_FRAMES, 0)
 
 
 def player(folder: str, save: bool, show: bool) -> None:

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -149,6 +149,7 @@ def hotkey(key: int) -> None:
     if mapped == "main":
         current = mapped
         vc = vcs[current]
+        update_trackbar(current)
         vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
     elif mapped in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
                     "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]:
@@ -156,11 +157,13 @@ def hotkey(key: int) -> None:
             if metadata["tracks"][mapped][index] != -1:
                 current = mapped
                 vc = vcs[current]
+                update_trackbar(current)
 
                 if index < len(metadata["tracks"][mapped]):
                     if metadata["tracks"][mapped][index] < 0:
                         current = "main"
                         vc = vcs[current]
+                        update_trackbar(current)
 
                     vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
 

--- a/src/kabr_tools/player.py
+++ b/src/kabr_tools/player.py
@@ -109,11 +109,11 @@ def draw_actions(current: str, index: int,
 
     if actions.get(current) is None:
         return image
-    elif actions[current].get(str(metadata["tracks"][current][index])) is None:
+    elif actions[current].get(str(index)) is None:
         return image
 
     color = metadata["colors"][current]
-    label = "|".join(actions[current][str(metadata["tracks"][current][index])].split(","))
+    label = "|".join(actions[current][str(index)].split(","))
     thickness_in = 4
     size = 1.5
     label_length = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, size, thickness_in)
@@ -230,13 +230,6 @@ def player(folder: str, save: bool, show: bool) -> None:
                              29.97, (target_width, target_height))
 
     while vc.isOpened():
-        if index < len(metadata["tracks"][current]):
-            if metadata["tracks"][current][index] < 0:
-                current = "main"
-                vc = vcs[current]
-                update_trackbar(current)
-                vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
-
         returned, frame = vc.read()
 
         if returned:
@@ -282,9 +275,8 @@ def player(folder: str, save: bool, show: bool) -> None:
                         break
                     elif letter2hotkey.get(key) is not None:
                         if letter2hotkey[key] in vcs.keys():
-                            if metadata["tracks"][letter2hotkey[key]][index] >= 0:
-                                hotkey(key)
-                                break
+                            hotkey(key)
+                            break
                     elif updated:
                         break
 
@@ -292,8 +284,7 @@ def player(folder: str, save: bool, show: bool) -> None:
                     break
             elif letter2hotkey.get(key) is not None:
                 if letter2hotkey[key] in vcs.keys():
-                    if metadata["tracks"][letter2hotkey[key]][index] >= 0:
-                        hotkey(key)
+                    hotkey(key)
 
             index += 1
         else:
@@ -303,7 +294,8 @@ def player(folder: str, save: bool, show: bool) -> None:
                 current = "main"
                 vc = vcs[current]
                 update_trackbar(current)
-                vc.set(cv2.CAP_PROP_POS_FRAMES, metadata["tracks"][current][index])
+                index = int(vc.get(cv2.CAP_PROP_POS_FRAMES))
+                cv2.setTrackbarPos(name, "TrackPlayer", index)
 
     if save:
         vw.release()

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -2,7 +2,8 @@ import unittest
 import sys
 import os
 from pathlib import Path
-from unittest.mock import patch
+import cv2 as real_cv2
+from unittest.mock import patch, MagicMock
 from kabr_tools import player
 from tests.utils import (
     del_file,
@@ -63,6 +64,13 @@ class TestPlayer(unittest.TestCase):
         run()
         self.assertTrue(file_exists(f"{self.folder}/{self.video}_demo.mp4"))
 
+        cap = real_cv2.VideoCapture(f"{self.folder}/{self.video}.mp4")
+        expected_max = int(cap.get(real_cv2.CAP_PROP_FRAME_COUNT)) - 1
+        cap.release()
+        createTrackbar.assert_called_once_with(
+            self.video, "TrackPlayer", 0, expected_max, player.on_slider_change
+        )
+
     @patch('kabr_tools.player.cv2.imshow')
     @patch('kabr_tools.player.cv2.namedWindow')
     @patch('kabr_tools.player.cv2.createTrackbar')
@@ -105,3 +113,17 @@ class TestPlayer(unittest.TestCase):
         # run player
         run()
         self.assertTrue(file_exists(f"{self.folder}/{self.video}_demo.mp4"))
+
+    @patch('kabr_tools.player.cv2.setTrackbarMax')
+    @patch('kabr_tools.player.cv2.setTrackbarPos')
+    def test_update_trackbar(self, setTrackbarPos, setTrackbarMax):
+        mock_cap = MagicMock()
+        mock_cap.get.return_value = 50.0
+        player.vcs = {"43": mock_cap}
+        player.name = self.video
+        player.index = 10
+
+        player.update_trackbar("43")
+
+        setTrackbarMax.assert_called_once_with(self.video, "TrackPlayer", 49)
+        setTrackbarPos.assert_not_called()

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -49,9 +49,10 @@ class TestPlayer(unittest.TestCase):
     @patch('kabr_tools.player.cv2.imshow')
     @patch('kabr_tools.player.cv2.namedWindow')
     @patch('kabr_tools.player.cv2.createTrackbar')
+    @patch('kabr_tools.player.cv2.setTrackbarMax')
     @patch('kabr_tools.player.cv2.setTrackbarPos')
     @patch('kabr_tools.player.cv2.getTrackbarPos')
-    def test_run(self, getTrackbarPos, setTrackbarPos, createTrackbar, namedWindow, imshow):
+    def test_run(self, getTrackbarPos, setTrackbarPos, setTrackbarMax, createTrackbar, namedWindow, imshow):
         # mock getTrackbarPos
         getTrackbarPos.return_value = 0
 
@@ -65,9 +66,10 @@ class TestPlayer(unittest.TestCase):
     @patch('kabr_tools.player.cv2.imshow')
     @patch('kabr_tools.player.cv2.namedWindow')
     @patch('kabr_tools.player.cv2.createTrackbar')
+    @patch('kabr_tools.player.cv2.setTrackbarMax')
     @patch('kabr_tools.player.cv2.setTrackbarPos')
     @patch('kabr_tools.player.cv2.getTrackbarPos')
-    def test_parse_arg_min(self, getTrackbarPos, setTrackbarPos, createTrackbar, namedWindow, imshow):
+    def test_parse_arg_min(self, getTrackbarPos, setTrackbarPos, setTrackbarMax, createTrackbar, namedWindow, imshow):
         # parse arguments
         sys.argv = [self.tool,
                     "--folder", self.folder]
@@ -86,9 +88,10 @@ class TestPlayer(unittest.TestCase):
     @patch('kabr_tools.player.cv2.imshow')
     @patch('kabr_tools.player.cv2.namedWindow')
     @patch('kabr_tools.player.cv2.createTrackbar')
+    @patch('kabr_tools.player.cv2.setTrackbarMax')
     @patch('kabr_tools.player.cv2.setTrackbarPos')
     @patch('kabr_tools.player.cv2.getTrackbarPos')
-    def test_parse_arg_full(self, getTrackbarPos, setTrackbarPos, createTrackbar, namedWindow, imshow):
+    def test_parse_arg_full(self, getTrackbarPos, setTrackbarPos, setTrackbarMax, createTrackbar, namedWindow, imshow):
         # parse arguments
         sys.argv = [self.tool,
                     "--folder", self.folder,


### PR DESCRIPTION
### Summary
The trackbar was initialized from metadata["tracks"]["main"] length rather than the actual frame count, causing the slider range to be wrong for drone footage. Switching to a miniscene also didn't update the trackbar max, so shorter miniscenes had an incorrect range.

### Changes
  - Initialize trackbar max from `CAP_PROP_FRAME_COUNT` instead of metadata track length
  - Call `update_trackbar()` on every track switch (hotkey and EOF fallback) to resize the slider to the current video's
  frame count
  - Seek by frame index directly in `on_slider_change` and `draw_actions`, removing the indirection through
  `metadata["tracks"]`
  - Remove stale -1 sentinel checks from the main loop

### Testing
Main Version:


https://github.com/user-attachments/assets/ad216838-4dd8-4d28-a839-eef9e26196c4


Fixed Version:

https://github.com/user-attachments/assets/72616ceb-c26f-40e1-9d08-05111a5e32c4



---

Closes #89